### PR TITLE
Multi stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python image from the Docker Hub, slim version for smaller size
-FROM python:3.10-slim as development
+FROM python:3.10-slim AS development
 
 # we set the working directory in the container to be /app
 WORKDIR /app
@@ -27,8 +27,8 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.10/site-packages/ 
-/usr/local/lib/python3.10/site-packages/
+COPY --from=development /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
+COPY --from=development /usr/local/bin/ /usr/local/bin/
 
 # copy rest of the application code into the container
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,34 @@
 # python image from the Docker Hub, slim version for smaller size
-FROM python:3.10-slim
+FROM python:3.10-slim as development
 
 # we set the working directory in the container to be /app
 WORKDIR /app
 
 # Install system dependencies needed for psycopg2 and PostgreSQL client libraries
 RUN apt-get update && apt-get install -y \
-    libpq-dev gcc netcat-openbsd --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
+    libpq-dev \
+    gcc \
+    netcat-openbsd \ 
+    --no-install-recommends
 
 # Copy the requirements.txt file into the container
 COPY requirements.txt .
-
 RUN pip install -r requirements.txt
+
+#production
+FROM python:3.10-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    netcat-openbsd \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.10/site-packages/ 
+/usr/local/lib/python3.10/site-packages/
 
 # copy rest of the application code into the container
 COPY . .
@@ -20,8 +36,6 @@ COPY . .
 # make sure that the entrypoint script is executable
 RUN chmod +x /app/entrypoint.sh
 
-# the entrypoint script contains the exec command, and verifies conditions
 ENTRYPOINT ["/app/entrypoint.sh"]
-# replaces CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
 
 


### PR DESCRIPTION
Key fixes:

Changed as to AS for consistency
Added proper destination path in the COPY commands
Added copying of binaries from builder stage

This should resolve the error. The issue was with Docker trying to pull a non-existent image called "builder" instead of understanding it as a stage name. 